### PR TITLE
version関連を修正

### DIFF
--- a/.github/workflows/add_tag.yaml
+++ b/.github/workflows/add_tag.yaml
@@ -17,3 +17,5 @@ jobs:
     steps:
       - name: Colcon Test
         uses: TRAPS-RoboCup/traps-github-action/ros2-add-tag@main
+        with:
+          token: ${{ secrets.PAT }}

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,7 @@ limitations under the License. -->
 
 <package format="3">
   <name>traps_example_ros</name>
-  <version>0.0.9</version>
+  <version>0.0.0</version>
   <description>TRAPSで使用するROS2のツール類</description>
   <maintainer email="traps.robocup@gmail.com">TRAPS</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
- versionを0.0.9から0.0.0に修正
- GitHub Workflowでtag付をしたときに再度docker buildするように修正